### PR TITLE
Modify the footer to allow for more elements, as well as provide options to show/hide each one of them.

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -61,6 +61,10 @@
       <label>Whether to show the "Recent Documents" category.</label>
       <default>true</default>
     </entry>
+    <entry name="gridAllowTwoLines" type="Bool">
+      <label>Whether to allow showing two lines in grid view.</label>
+      <default>true</default>
+    </entry>
     <entry name="showRecentContacts" type="Bool">
       <label>Whether to show the "Recent Contacts" category.</label>
       <default>false</default>
@@ -76,6 +80,46 @@
     </entry>
     <entry name="centerMenu" type="Bool">
       <label>Whether to center the popup Menu.</label>
+      <default>true</default>
+    </entry>
+    <entry name="alwaysShowSearchBar" type="Bool">
+      <label>Whether to always show the search bar on top of the menu or not.</label>
+      <default>false</default>
+    </entry>
+    <entry name="downIconsDocuments" type="Bool">
+      <label>Shows or hides the Documents shortcut on the bottom bar.</label>
+      <default>false</default>
+    </entry>
+    <entry name="downIconsPictures" type="Bool">
+      <label>Shows or hides the Pictures shortcut on the bottom bar.</label>
+      <default>false</default>
+    </entry>
+    <entry name="downIconsMusic" type="Bool">
+      <label>Shows or hides the Music shortcut on the bottom bar.</label>
+      <default>false</default>
+    </entry>
+    <entry name="downIconsDownloads" type="Bool">
+      <label>Shows or hides the Downloads shortcut on the bottom bar.</label>
+      <default>false</default>
+    </entry>
+    <entry name="downIconsVideos" type="Bool">
+      <label>Shows or hides the Videos shortcut on the bottom bar.</label>
+      <default>false</default>
+    </entry>
+    <entry name="downIconsFileManager" type="Bool">
+      <label>Shows or hides the File Manager (aka Dolphin) shortcut on the bottom bar.</label>
+      <default>false</default>
+    </entry>
+    <entry name="downIconsSystemSettings" type="Bool">
+      <label>Shows or hides the System Settings shortcut on the bottom bar.</label>
+      <default>true</default>
+    </entry>
+    <entry name="downIconsLock" type="Bool">
+      <label>Shows or hides the Lock button on the bottom bar.</label>
+      <default>true</default>
+    </entry>
+    <entry name="downIconsPowerOptions" type="Bool">
+      <label>Shows or hides the Power Options button on the bottom bar.</label>
       <default>true</default>
     </entry>
     <entry name="showIconsRootLevel" type="Bool">

--- a/contents/ui/ConfigGeneral.qml
+++ b/contents/ui/ConfigGeneral.qml
@@ -52,7 +52,16 @@ Kirigami.FormLayout {
 
     property alias cfg_useExtraRunners: useExtraRunners.checked
     property alias cfg_centerMenu: centerMenu.checked
-
+    
+    property alias cfg_downIconsDocuments: downIconsDocuments.checked
+    property alias cfg_downIconsDownloads: downIconsDownloads.checked
+    property alias cfg_downIconsPictures: downIconsPictures.checked
+    property alias cfg_downIconsMusic: downIconsMusic.checked
+    property alias cfg_downIconsVideos: downIconsVideos.checked
+    property alias cfg_downIconsFileManager: downIconsFileManager.checked
+    property alias cfg_downIconsSystemSettings: downIconsSystemSettings.checked
+    property alias cfg_downIconsLock: downIconsLock.checked
+    property alias cfg_downIconsPowerOptions: downIconsPowerOptions.checked
 
     Button {
         id: iconButton
@@ -199,6 +208,56 @@ Kirigami.FormLayout {
         visible: !isDash
 
         text: i18n("Show icons on the root level of the menu")
+    }
+    
+    Item {
+        Kirigami.FormData.isSection: true
+    }
+
+    CheckBox {
+        id: downIconsDocuments
+        Kirigami.FormData.label: i18n("Icons on Bottom bar:")
+        text: i18n("Documents")
+    }
+
+    CheckBox {
+        id: downIconsPictures
+        text: i18n("Pictures")
+    }
+
+    CheckBox {
+        id: downIconsMusic
+        text: i18n("Music")
+    }
+
+    CheckBox {
+        id: downIconsDownloads
+        text: i18n("Downloads")
+    }
+
+    CheckBox {
+        id: downIconsVideos
+        text: i18n("Videos")
+    }
+
+    CheckBox {
+        id: downIconsFileManager
+        text: i18n("File Manager")
+    }
+
+    CheckBox {
+        id: downIconsSystemSettings
+        text: i18n("System Settings")
+    }
+
+    CheckBox {
+        id: downIconsLock
+        text: i18n("Lock")
+    }
+
+    CheckBox {
+        id: downIconsPowerOptions
+        text: i18n("Power Options")
     }
 
     Item {

--- a/contents/ui/Footer.qml
+++ b/contents/ui/Footer.qml
@@ -200,7 +200,11 @@ PlasmaExtras.PlasmoidHeading {
                 duration: PlasmaCore.Units.longDuration
                 easing.type: Easing.InOutQuad
             }
-            icon.name: "folder-documents-symbolic"
+
+            icon {
+                name: "folder-documents-symbolic"
+                size: iconSize
+            }
             onHoveredChanged: hovered ? animateDocumentsOpacity.start() : animateDocumentsOpacityReverse.start();
             PlasmaComponents.ToolTip {
                 text: i18nc("@action", "Documents")
@@ -236,7 +240,10 @@ PlasmaExtras.PlasmoidHeading {
                 duration: PlasmaCore.Units.longDuration
                 easing.type: Easing.InOutQuad
             }
-            icon.name: "folder-pictures-symbolic"
+            icon {
+                name: "folder-pictures-symbolic"
+                size: iconSize
+            }
             onHoveredChanged: hovered ? animatePicturesOpacity.start() : animatePicturesOpacityReverse.start();
             PlasmaComponents.ToolTip {
                 text: i18nc("@action", "Pictures")
@@ -272,7 +279,10 @@ PlasmaExtras.PlasmoidHeading {
                 duration: PlasmaCore.Units.longDuration
                 easing.type: Easing.InOutQuad
             }
-            icon.name: "folder-music-symbolic"
+            icon {
+                name: "folder-music-symbolic"
+                size: iconSize
+            }
             onHoveredChanged: hovered ? animateMusicOpacity.start() : animateMusicOpacityReverse.start();
             PlasmaComponents.ToolTip {
                 text: i18nc("@action", "Music")
@@ -308,7 +318,10 @@ PlasmaExtras.PlasmoidHeading {
                 duration: PlasmaCore.Units.longDuration
                 easing.type: Easing.InOutQuad
             }
-            icon.name: "folder-download-symbolic"
+            icon {
+                name: "folder-download-symbolic"
+                size: iconSize
+            }
             onHoveredChanged: hovered ? animateDownloadsOpacity.start() : animateDownloadsOpacityReverse.start();
             PlasmaComponents.ToolTip {
                 text: i18nc("@action", "Downloads")
@@ -344,7 +357,10 @@ PlasmaExtras.PlasmoidHeading {
                 duration: PlasmaCore.Units.longDuration
                 easing.type: Easing.InOutQuad
             }
-            icon.name: "folder-videos-symbolic"
+            icon {
+                name: "folder-videos-symbolic"
+                size: iconSize
+            }
             onHoveredChanged: hovered ? animateVideosOpacity.start() : animateVideosOpacityReverse.start();
             PlasmaComponents.ToolTip {
                 text: i18nc("@action", "Videos")
@@ -380,7 +396,10 @@ PlasmaExtras.PlasmoidHeading {
                 duration: PlasmaCore.Units.longDuration
                 easing.type: Easing.InOutQuad
             }
-            icon.name: "folder-symbolic"
+            icon {
+                name: "system-file-manager-symbolic"
+                size: iconSize
+            }
             onHoveredChanged: hovered ? animateFileManagerOpacity.start() : animateFileManagerOpacityReverse.start();
             PlasmaComponents.ToolTip {
                 text: i18nc("@action", "File Manager")
@@ -416,7 +435,10 @@ PlasmaExtras.PlasmoidHeading {
                 duration: PlasmaCore.Units.longDuration
                 easing.type: Easing.InOutQuad
             }
-            icon.name: "configure"
+            icon {
+                name: "configure"
+                size: iconSize
+            }
             onHoveredChanged: hovered ? animateSettingsOpacity.start() : animateSettingsOpacityReverse.start();
             PlasmaComponents.ToolTip {
                 text: i18nc("@action", "System settings")
@@ -452,7 +474,10 @@ PlasmaExtras.PlasmoidHeading {
                 duration: PlasmaCore.Units.longDuration
                 easing.type: Easing.InOutQuad
             }
-            icon.name: "system-lock-screen"
+            icon {
+                name: "system-lock-screen"
+                size: iconSize
+            }
             onHoveredChanged: hovered ? animateLockOpacity.start() : animateLockOpacityReverse.start();
             enabled: pmEngine.data["Sleep States"]["LockScreen"]
             PlasmaComponents.ToolTip {
@@ -489,7 +514,10 @@ PlasmaExtras.PlasmoidHeading {
                 easing.type: Easing.InOutQuad
             }
             onHoveredChanged: hovered ? animateOpacity.start() : animateOpacityReverse.start();
-            icon.name: "system-shutdown"
+            icon {
+                name: "system-shutdown"
+                size: iconSize
+            }
             PlasmaComponents.ToolTip {
                 text: i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Leave...")
             }

--- a/contents/ui/Footer.qml
+++ b/contents/ui/Footer.qml
@@ -177,12 +177,14 @@ PlasmaExtras.PlasmoidHeading {
         // looks visually balanced that way
         spacing: Math.round(PlasmaCore.Units.smallSpacing * 2.5)
 
+        // Documents Button
         PlasmaComponents.TabButton {
-            id: fileExplorerButton
-            // flat: true 
+            id: documentsButton
+            visible: plasmoid.configuration.downIconsDocuments
+            // flat: true
             NumberAnimation {
-                id: animateExplorerOpacity
-                target: fileExplorerButton
+                id: animateDocumentsOpacity
+                target: documentsButton
                 properties: "opacity"
                 from: 1
                 to: 0.5
@@ -190,33 +192,212 @@ PlasmaExtras.PlasmoidHeading {
                 easing.type: Easing.InOutQuad
             }
             NumberAnimation {
-                id: animateExplorerOpacityReverse
-                target: fileExplorerButton
+                id: animateDocumentsOpacityReverse
+                target: documentsButton
                 properties: "opacity"
                 from: 0.5
                 to: 1
                 duration: PlasmaCore.Units.longDuration
                 easing.type: Easing.InOutQuad
             }
-            icon{
-                name: "system-file-manager-symbolic"
-                width: iconSize * 0.96
-            }
-            onHoveredChanged: hovered ? animateExplorerOpacity.start() : animateExplorerOpacityReverse.start();
+            icon.name: "folder-documents-symbolic"
+            onHoveredChanged: hovered ? animateDocumentsOpacity.start() : animateDocumentsOpacityReverse.start();
             PlasmaComponents.ToolTip {
-                text: i18nc("@action", "File Explorer")
+                text: i18nc("@action", "Documents")
             }
             MouseArea {
-                onClicked: executable.exec("dolphin")
+                onClicked: executable.exec("xdg-open $(xdg-user-dir DOCUMENTS)")
                 anchors.fill: parent
                 hoverEnabled: true
                 cursorShape: containsMouse ? Qt.PointingHandCursor : Qt.ArrowCursor
             }
         }
 
+        // Pictures Button
+        PlasmaComponents.TabButton {
+            id: picturesButton
+            visible: plasmoid.configuration.downIconsPictures
+            // flat: true
+            NumberAnimation {
+                id: animatePicturesOpacity
+                target: picturesButton
+                properties: "opacity"
+                from: 1
+                to: 0.5
+                duration: PlasmaCore.Units.longDuration
+                easing.type: Easing.InOutQuad
+            }
+            NumberAnimation {
+                id: animatePicturesOpacityReverse
+                target: picturesButton
+                properties: "opacity"
+                from: 0.5
+                to: 1
+                duration: PlasmaCore.Units.longDuration
+                easing.type: Easing.InOutQuad
+            }
+            icon.name: "folder-pictures-symbolic"
+            onHoveredChanged: hovered ? animatePicturesOpacity.start() : animatePicturesOpacityReverse.start();
+            PlasmaComponents.ToolTip {
+                text: i18nc("@action", "Pictures")
+            }
+            MouseArea {
+                onClicked: executable.exec("xdg-open $(xdg-user-dir PICTURES)")
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: containsMouse ? Qt.PointingHandCursor : Qt.ArrowCursor
+            }
+        }
+
+        // Downloads Button
+        PlasmaComponents.TabButton {
+            id: musicButton
+            visible: plasmoid.configuration.downIconsMusic
+            // flat: true
+            NumberAnimation {
+                id: animateMusicOpacity
+                target: musicButton
+                properties: "opacity"
+                from: 1
+                to: 0.5
+                duration: PlasmaCore.Units.longDuration
+                easing.type: Easing.InOutQuad
+            }
+            NumberAnimation {
+                id: animateMusicOpacityReverse
+                target: musicButton
+                properties: "opacity"
+                from: 0.5
+                to: 1
+                duration: PlasmaCore.Units.longDuration
+                easing.type: Easing.InOutQuad
+            }
+            icon.name: "folder-music-symbolic"
+            onHoveredChanged: hovered ? animateMusicOpacity.start() : animateMusicOpacityReverse.start();
+            PlasmaComponents.ToolTip {
+                text: i18nc("@action", "Music")
+            }
+            MouseArea {
+                onClicked: executable.exec("xdg-open $(xdg-user-dir MUSIC)")
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: containsMouse ? Qt.PointingHandCursor : Qt.ArrowCursor
+            }
+        }
+
+        // Downloads Button
+        PlasmaComponents.TabButton {
+            id: downloadsButton
+            visible: plasmoid.configuration.downIconsDownloads
+            // flat: true
+            NumberAnimation {
+                id: animateDownloadsOpacity
+                target: downloadsButton
+                properties: "opacity"
+                from: 1
+                to: 0.5
+                duration: PlasmaCore.Units.longDuration
+                easing.type: Easing.InOutQuad
+            }
+            NumberAnimation {
+                id: animateDownloadsOpacityReverse
+                target: downloadsButton
+                properties: "opacity"
+                from: 0.5
+                to: 1
+                duration: PlasmaCore.Units.longDuration
+                easing.type: Easing.InOutQuad
+            }
+            icon.name: "folder-download-symbolic"
+            onHoveredChanged: hovered ? animateDownloadsOpacity.start() : animateDownloadsOpacityReverse.start();
+            PlasmaComponents.ToolTip {
+                text: i18nc("@action", "Downloads")
+            }
+            MouseArea {
+                onClicked: executable.exec("xdg-open $(xdg-user-dir DOWNLOAD)")
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: containsMouse ? Qt.PointingHandCursor : Qt.ArrowCursor
+            }
+        }
+
+        // Videos Button
+        PlasmaComponents.TabButton {
+            id: videosButton
+            visible: plasmoid.configuration.downIconsVideos
+            // flat: true
+            NumberAnimation {
+                id: animateVideosOpacity
+                target: videosButton
+                properties: "opacity"
+                from: 1
+                to: 0.5
+                duration: PlasmaCore.Units.longDuration
+                easing.type: Easing.InOutQuad
+            }
+            NumberAnimation {
+                id: animateVideosOpacityReverse
+                target: videosButton
+                properties: "opacity"
+                from: 0.5
+                to: 1
+                duration: PlasmaCore.Units.longDuration
+                easing.type: Easing.InOutQuad
+            }
+            icon.name: "folder-videos-symbolic"
+            onHoveredChanged: hovered ? animateVideosOpacity.start() : animateVideosOpacityReverse.start();
+            PlasmaComponents.ToolTip {
+                text: i18nc("@action", "Videos")
+            }
+            MouseArea {
+                onClicked: executable.exec("xdg-open $(xdg-user-dir VIDEOS)")
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: containsMouse ? Qt.PointingHandCursor : Qt.ArrowCursor
+            }
+        }
+
+        // File Manager Button
+        PlasmaComponents.TabButton {
+            id: fileManagerButton
+            visible: plasmoid.configuration.downIconsFileManager
+            // flat: true
+            NumberAnimation {
+                id: animateFileManagerOpacity
+                target: fileManagerButton
+                properties: "opacity"
+                from: 1
+                to: 0.5
+                duration: PlasmaCore.Units.longDuration
+                easing.type: Easing.InOutQuad
+            }
+            NumberAnimation {
+                id: animateFileManagerOpacityReverse
+                target: fileManagerButton
+                properties: "opacity"
+                from: 0.5
+                to: 1
+                duration: PlasmaCore.Units.longDuration
+                easing.type: Easing.InOutQuad
+            }
+            icon.name: "folder-symbolic"
+            onHoveredChanged: hovered ? animateFileManagerOpacity.start() : animateFileManagerOpacityReverse.start();
+            PlasmaComponents.ToolTip {
+                text: i18nc("@action", "File Manager")
+            }
+            MouseArea {
+                onClicked: executable.exec("xdg-open $(xdg-user-dir)")
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: containsMouse ? Qt.PointingHandCursor : Qt.ArrowCursor
+            }
+        }
+
+        // System Settings Button
         PlasmaComponents.TabButton {
             id: settingsButton
-            // flat: true 
+            visible: plasmoid.configuration.downIconsSystemSettings
+            // flat: true
             NumberAnimation {
                 id: animateSettingsOpacity
                 target: settingsButton
@@ -235,10 +416,7 @@ PlasmaExtras.PlasmoidHeading {
                 duration: PlasmaCore.Units.longDuration
                 easing.type: Easing.InOutQuad
             }
-            icon{
-                name: "configure"
-                width: iconSize
-            }
+            icon.name: "configure"
             onHoveredChanged: hovered ? animateSettingsOpacity.start() : animateSettingsOpacityReverse.start();
             PlasmaComponents.ToolTip {
                 text: i18nc("@action", "System settings")
@@ -251,8 +429,47 @@ PlasmaExtras.PlasmoidHeading {
             }
         }
 
+        // Lock Button
+        PlasmaComponents.TabButton {
+            id: lockScreenButton
+            visible: plasmoid.configuration.downIconsLock
+            // flat: true 
+            NumberAnimation {
+                id: animateLockOpacity
+                target: lockScreenButton
+                properties: "opacity"
+                from: 1
+                to: 0.5
+                duration: PlasmaCore.Units.longDuration
+                easing.type: Easing.InOutQuad
+            }
+            NumberAnimation {
+                id: animateLockOpacityReverse
+                target: lockScreenButton
+                properties: "opacity"
+                from: 0.5
+                to: 1
+                duration: PlasmaCore.Units.longDuration
+                easing.type: Easing.InOutQuad
+            }
+            icon.name: "system-lock-screen"
+            onHoveredChanged: hovered ? animateLockOpacity.start() : animateLockOpacityReverse.start();
+            enabled: pmEngine.data["Sleep States"]["LockScreen"]
+            PlasmaComponents.ToolTip {
+                text: i18nc("@action", "Lock screen")
+            }
+            MouseArea {
+                onClicked: pmEngine.performOperation("lockScreen")
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: containsMouse ? Qt.PointingHandCursor : Qt.ArrowCursor
+            }
+        }
+
+        // Power Off Button
         PlasmaComponents.TabButton {
             id: leaveButton
+            visible: plasmoid.configuration.downIconsPowerOptions
             NumberAnimation {
                 id: animateOpacity
                 target: leaveButton
@@ -272,10 +489,7 @@ PlasmaExtras.PlasmoidHeading {
                 easing.type: Easing.InOutQuad
             }
             onHoveredChanged: hovered ? animateOpacity.start() : animateOpacityReverse.start();
-            icon{
-                name: "system-shutdown"
-                width: iconSize
-            }
+            icon.name: "system-shutdown"
             PlasmaComponents.ToolTip {
                 text: i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Leave...")
             }

--- a/contents/ui/Footer.qml
+++ b/contents/ui/Footer.qml
@@ -398,7 +398,7 @@ PlasmaExtras.PlasmoidHeading {
             }
             icon {
                 name: "system-file-manager-symbolic"
-                size: iconSize
+                width: iconSize * 0.96
             }
             onHoveredChanged: hovered ? animateFileManagerOpacity.start() : animateFileManagerOpacityReverse.start();
             PlasmaComponents.ToolTip {
@@ -437,7 +437,7 @@ PlasmaExtras.PlasmoidHeading {
             }
             icon {
                 name: "configure"
-                size: iconSize
+                width: iconSize
             }
             onHoveredChanged: hovered ? animateSettingsOpacity.start() : animateSettingsOpacityReverse.start();
             PlasmaComponents.ToolTip {
@@ -516,7 +516,7 @@ PlasmaExtras.PlasmoidHeading {
             onHoveredChanged: hovered ? animateOpacity.start() : animateOpacityReverse.start();
             icon {
                 name: "system-shutdown"
-                size: iconSize
+                width: iconSize
             }
             PlasmaComponents.ToolTip {
                 text: i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Leave...")


### PR DESCRIPTION
This set of commits enables one to show/hide following folders right before the lock/power buttons:
- Documents
- Pictures
- Music
- Downloads
- Videos

As well as allows for hiding/showing the following options:
- File Manager (possibly of your choice, as the commands use "xdg-open")
- System Settings
- Lock Screen
- Power Options ("Leave...")

For all of the given options above, check boxes are provided in Menu's settings window.

Currently the only issue with this is depending on the user name's length, the icons may end up on top of the text in case of having almost all of them shown.

Example screenshot:

![image](https://user-images.githubusercontent.com/86886753/124362423-5ad5aa00-dc3d-11eb-97a9-667ca0139849.png)

With the following settings:

![image](https://user-images.githubusercontent.com/86886753/124362463-aee08e80-dc3d-11eb-99d7-2c4ecd2e91d8.png)
