### PR TITLE
Fix 'More' reset bug

### DIFF
--- a/contents/ui/MainColumnItem.qml
+++ b/contents/ui/MainColumnItem.qml
@@ -73,6 +73,7 @@ Item {
         documentsFavoritesGrid.tryActivate(0, 0);
         allAppsGrid.tryActivate(0, 0);
         globalFavoritesGrid.tryActivate(0, 0);
+        resetPinned.start();
     }
 
     function reload() {
@@ -115,6 +116,14 @@ Item {
         NumberAnimation { target: documentsFavoritesGrid; property: "height"; from: parent.height; to: favoritesColumnHeight; duration: 500; easing.type: Easing.InOutQuad }
     }
 
+    ParallelAnimation {
+        id: resetPinned
+        running: false
+        NumberAnimation { target: mainColumn; property: "height"; from: 0; to: searching || showAllApps ? parent.height : mainColumnHeight; duration: 0; }
+        NumberAnimation { target: mainColumn; property: "opacity"; from: 0; to: 1; duration: 0; }
+        NumberAnimation { target: documentsFavoritesGrid; property: "height"; from: parent.height; to: favoritesColumnHeight; duration: 0; }
+    }
+    
     TextMetrics {
         id: headingMetrics
         font: dummyHeading.font


### PR DESCRIPTION
When 'More' is active and window is deactivated after, the recents overlap the Pinned menu which looks like a glitch.
To fix this, I have added a reset animation that sets the Recommended section back when window is deactivated.